### PR TITLE
Fix checkout command (bug 1058536)

### DIFF
--- a/bin/mkt
+++ b/bin/mkt
@@ -6,7 +6,6 @@ import os
 import subprocess
 import sys
 import textwrap
-import tarfile
 
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
@@ -22,11 +21,14 @@ BRANCHES = [
     'zippy',
 ]
 
+
 def indent(text, times=1):
-    wrapper = textwrap.TextWrapper(initial_indent='  '*times, width=90,
-                                   subsequent_indent='  '*times)
+    wrapper = textwrap.TextWrapper(
+        initial_indent='  '*times, width=90, subsequent_indent='  '*times
+    )
     for line in text.splitlines():
         print wrapper.fill(line)
+
 
 def check_git_config(args, parser):
     for branch in BRANCHES:
@@ -39,7 +41,8 @@ def check_git_config(args, parser):
                 indent("[remotes]")
                 indent(subprocess.check_output(['git', 'remote', '-v']), 2)
                 indent("[Master branch origin]")
-                origin = subprocess.check_output(['git', 'config', '--get', 'branch.master.remote'])
+                origin = subprocess.check_output(['git', 'config', '--get',
+                                                  'branch.master.remote'])
                 indent(origin, 2)
                 print
             finally:
@@ -47,19 +50,29 @@ def check_git_config(args, parser):
 
 
 def checkout(args, parser):
-    github_username = whoami(quiet=True)
-    if not github_username:
-        parser.error('Please set a github username with the "whoami" command first')
+    gh_username = whoami(quiet=True)
+    if not gh_username:
+        parser.error('Please set a github username with the "whoami" '
+                     'command first')
 
     for branch in BRANCHES:
         tree_dir = os.path.join(TREES_DIR, branch)
-        if not os.path.isdir(tree_dir):
-            subprocess.call(['git', 'clone', '-o', args.moz_remote_name,
-                             'git@github.com:mozilla/{1}.git'.format(branch), tree_dir])
-            subprocess.call(['git', 'remote', 'add', args.fork_remote_name,
-                             'git@github.com:{0}/{0}.git'.format(github_username, branch)], cwd=tree_dir)
-            subprocess.call(['git', 'config', 'branch.master.remote', args.fork_remote_name])
 
+        if not os.path.isdir(tree_dir):
+            subprocess.call([
+                'git', 'clone', '-o', args.moz_remote_name,
+                'git@github.com:mozilla/{1}.git'.format(branch),
+                tree_dir
+            ])
+
+            subprocess.call([
+                'git', 'remote', 'add', args.fork_remote_name,
+                'git@github.com:{0}/{0}.git'.format(gh_username, branch)
+            ], cwd=tree_dir)
+
+            subprocess.call([
+                'git', 'config', 'branch.master.remote', args.fork_remote_name
+            ])
 
 
 def get_image(args, parser):
@@ -67,7 +80,8 @@ def get_image(args, parser):
     image_dir = os.path.join(IMAGES_DIR, image_name)
 
     if not os.path.isdir(image_dir):
-        parser.error('image_dir: {0} does not exist. Exiting'.format(image_dir))
+        parser.error('image_dir: {0} does not exist. '
+                     'Exiting'.format(image_dir))
 
     return {
         'name': image_name,
@@ -102,7 +116,8 @@ def whoami(args=None, parser=None, quiet=False):
         if user:
             print('github user: {0}'.format(user))
         else:
-            print('Try setting your github username with "wharfie whoami [github_username]"')
+            print('Try setting your github username with '
+                  '"mkt whoami [github_username]"')
 
     return user
 
@@ -110,43 +125,69 @@ def whoami(args=None, parser=None, quiet=False):
 def shell(args, parser):
     image = get_image(args, parser)
     image_name = image['name']
-    return subprocess.call(['docker', 'run', '-a', 'stdin', '-a', 'stdout', '-i', '-t', image_name + '_img', '/bin/bash'])
+    return subprocess.call(['docker', 'run', '-a', 'stdin', '-a', 'stdout',
+                            '-i', '-t', image_name + '_img', '/bin/bash'])
 
 
 def main():
 
-    image_name_help = 'The name of the image to build. Should map to images/[name]'
+    image_name_help = 'The name of the image to build. Should map to ' \
+                      'images/[name]'
     parser = argparse.ArgumentParser(description='Wharfie')
-    subparsers = parser.add_subparsers(help='See each command for additional help', title='Sub-commands', description='Valid commands')
+
+    subparsers = parser.add_subparsers(
+        help='See each command for additional help',
+        title='Sub-commands', description='Valid commands'
+    )
 
     if not os.path.isdir(IMAGES_DIR):
-        parser.error('IMAGES_DIR: {0} does not exist. Exiting'.format(IMAGES_DIR))
+        parser.error('IMAGES_DIR: {0} does not exist. '
+                     'Exiting'.format(IMAGES_DIR))
 
     VALID_SUBDIRS = os.walk(IMAGES_DIR).next()[1]
 
-    parser_shell = subparsers.add_parser('shell', help='Run image, and drop into a shell on it.')
-    parser_shell.add_argument('name', help=image_name_help, metavar="IMAGE_NAME", choices=VALID_SUBDIRS)
+    parser_shell = subparsers.add_parser(
+        'shell', help='Run image, and drop into a shell on it.'
+    )
+    parser_shell.add_argument(
+        'name', help=image_name_help, metavar="IMAGE_NAME",
+        choices=VALID_SUBDIRS
+    )
     parser_shell.set_defaults(func=shell)
-
-    parser_shell = subparsers.add_parser('chkgitconfig', help='Print out the git config for mkt branches')
+    parser_shell = subparsers.add_parser(
+        'chkgitconfig', help='Print out the git config for mkt branches'
+    )
     parser_shell.set_defaults(func=check_git_config)
 
-    parser_whoami = subparsers.add_parser('whoami', help='Check your github credentials')
-    parser_whoami.add_argument('github_username', help='Your github username e.g. "jrrtolkien"', metavar="USER_NAME", default=None, nargs='?')
+    parser_whoami = subparsers.add_parser(
+        'whoami', help='Check your github credentials'
+    )
+    parser_whoami.add_argument(
+        'github_username', help='Your github username e.g. "jrrtolkien"',
+        metavar="USER_NAME", default=None, nargs='?'
+    )
     parser_whoami.set_defaults(func=whoami)
 
-    parser_checkout = subparsers.add_parser('checkout', help='Checkout your forks of sourcecode')
-    parser_checkout.add_argument('moz_remote_name', help='What to call the mozilla repo remote for this project. Following '
-        'github terminology this defaults to "upstream"',
-        metavar="MOZ_REMOTE_NAME", default='upstream', nargs='?')
-    parser_checkout.add_argument('fork_remote_name', help='What to call your fork remote for this project. Following github '
-        'terminology this defaults to "origin")',
-        metavar="FORK_REMOTE_NAME", default='origin', nargs='?')
+    parser_checkout = subparsers.add_parser(
+        'checkout', help='Checkout your forks of sourcecode'
+    )
+    parser_checkout.add_argument(
+        'moz_remote_name',
+        help='What to call the mozilla repo remote for this project. '
+             'Following github terminology this defaults to "upstream"',
+        metavar="MOZ_REMOTE_NAME",
+        default='upstream', nargs='?'
+    )
+    parser_checkout.add_argument(
+        'fork_remote_name',
+        help='What to call your fork remote for this project. Following '
+             'github terminology this defaults to "origin"',
+        metavar="FORK_REMOTE_NAME", default='origin', nargs='?'
+    )
     parser_checkout.set_defaults(func=checkout)
 
     args = parser.parse_args()
     args.func(args, parser)
-
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
This fixes checkout to use the moz repos as the clone source.
It defaults to calling moz repos `upstream` and forks `origin` you can override this with command args.

e.g: default command usage would be:

`bin/mkt checkout`

For people with inverted upstream/origin this would work:

`bin/mkt checkout --moz_remote_name=origin --fork_remote_name=upstream`

This also makes sure the branch.master.origin setting in the local repo is set to match your fork (so the default for push is sane)

Lastly there's a new command to check the trees setup.

`bin/mkt chkgitconfig`

Here's example output (This is with inverted upstream/origin - which isn't the default)

```
[fireplace]
  [remotes]
    origin  git@github.com:mozilla/fireplace.git (fetch)
    origin  git@github.com:mozilla/fireplace.git (push)
    upstream        git@github.com:muffinresearch/fireplace.git (fetch)
    upstream        git@github.com:muffinresearch/fireplace.git (push)
  [Master branch origin]
    upstream

[spartacus]
  [remotes]
    origin  git@github.com:mozilla/spartacus.git (fetch)
    origin  git@github.com:mozilla/spartacus.git (push)
    upstream        git@github.com:muffinresearch/spartacus.git (fetch)
    upstream        git@github.com:muffinresearch/spartacus.git (push)
  [Master branch origin]
    upstream
```

r? @andymckay 
