### PR TITLE
Add shell completion

### DIFF
--- a/mkt/bin.py
+++ b/mkt/bin.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+import argcomplete
 import sys
 import cmds
 
 
 def main():
-
     parser = cmds.create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
     args.func(args, parser)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argcomplete==0.8.3
 docker-py==0.5.3
 dockerpty==0.3.2
 docopt==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ setup(
     },
     package_data=get_package_data('mkt'),
     install_requires=[
+        'argcomplete',
         'fig',
         'netifaces'
     ],
     zip_safe=False
 )
-


### PR DESCRIPTION
This adds shell (base or zsh) completion. You can either run:

`activate-global-python-argcomplete` to activate global completion (linux or osx with a more recent than standard bash).

Or add:

`eval "$(register-python-argcomplete mkt)"` to your profile.

See also https://github.com/mozilla/marketplace-docs/pull/44
