### PR TITLE
Default master to the moz branch in checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ images/boot2docker/Dockerfile
 
 # This comes from fig.yml.dist
 fig.yml
+
+# Ignore vagrant files from testing.
+.vagrant
+Vagrantfile

--- a/mkt/cmds.py
+++ b/mkt/cmds.py
@@ -115,7 +115,7 @@ def checkout(args, parser, gh_username=None):
             ], cwd=branch_dir)
 
             subprocess.call([
-                'git', 'config', 'branch.master.remote', args.fork_remote_name
+                'git', 'config', 'branch.master.remote', args.moz_remote_name
             ])
 
 

--- a/mkt/tests/test_commands.py
+++ b/mkt/tests/test_commands.py
@@ -146,7 +146,7 @@ class TestCommands(TestBase):
                 ], cwd='{0}/foo'.format(directory)),
                 mock.call([
                     'git', 'config',
-                    'branch.master.remote', 'origin'
+                    'branch.master.remote', 'upstream'
                 ])
             ])
 
@@ -176,7 +176,7 @@ class TestCommands(TestBase):
                 ], cwd='{0}/foo'.format(directory)),
                 mock.call([
                     'git', 'config',
-                    'branch.master.remote', 'upstream'
+                    'branch.master.remote', 'origin'
                 ])
             ])
 


### PR DESCRIPTION
So that the `git pull` used by `mkt update` uses the mozilla repo's master the checkout should set the correct master branch. Default is upstream for the mozilla repo and origin for your checkout (as per github's normal checkout workflow) but if you override this as some people do then it should be set to origin (where origin is the mozilla repo).

r? @andymckay 