### PR TITLE
Test removing the mysql data container WiP

### DIFF
--- a/mkt/cmds.py
+++ b/mkt/cmds.py
@@ -38,7 +38,6 @@ BRANCHES = [
 IMAGES = [
     'elasticsearch',
     'memcached',
-    'mysql-data',
     'mysql-service',
     'nginx',
     'redis'

--- a/mkt/data/fig.yml.dist
+++ b/mkt/data/fig.yml.dist
@@ -46,15 +46,10 @@ memcached:
   environment:
     - TERM=xterm-256color
 
-mysqldata:
-  build: {image}/mysql-data
-
 mysql:
   build: {image}/mysql-service
   environment:
     - TERM=xterm-256color
-  volumes_from:
-    - mysqldata
 
 redis:
   build: {image}/redis

--- a/mkt/data/images/mysql-data/Dockerfile
+++ b/mkt/data/images/mysql-data/Dockerfile
@@ -1,5 +1,0 @@
-FROM busybox
-
-VOLUME /var/lib/mysql
-
-CMD ["true"]

--- a/mkt/data/images/mysql-service/Dockerfile
+++ b/mkt/data/images/mysql-service/Dockerfile
@@ -4,6 +4,8 @@ ADD my.cnf /etc/mysql/conf.d/my.cnf
 ADD setup.sh /setup.sh
 ADD run.sh /run.sh
 
+VOLUME /var/lib/mysql
+
 EXPOSE 3306
 
 CMD ["/bin/bash", "/run.sh"]


### PR DESCRIPTION
I'm not sure about this. If you rm the mysql-service container that means the data is gone.  

I'm going to look into data-only containers a bit more to make sure we understand what we might be losing by doing this. I think we could probably tweak the command if nothing else.

Interesting reading: 

http://container42.com/2014/11/18/data-only-container-madness/