### PR TITLE
Fix mysql memory usage

### DIFF
--- a/mkt/data/images/mysql-service/Dockerfile
+++ b/mkt/data/images/mysql-service/Dockerfile
@@ -1,6 +1,7 @@
 FROM mozillamarketplace/centos-mysql-mkt:0.2
 
-ADD my.cnf /etc/mysql/conf.d/my.cnf
+RUN mv /etc/my.cnf{,.bck}
+ADD my.cnf /etc/my.cnf
 ADD setup.sh /setup.sh
 ADD run.sh /run.sh
 

--- a/mkt/data/images/mysql-service/my.cnf
+++ b/mkt/data/images/mysql-service/my.cnf
@@ -1,2 +1,41 @@
 [mysqld]
 bind-address=0.0.0.0
+
+innodb_buffer_pool_size=5M
+innodb_log_buffer_size=256K
+query_cache_size=0
+max_connections=10
+key_buffer_size=8
+thread_cache_size=0
+host_cache_size=0
+innodb_ft_cache_size=1600000
+innodb_ft_total_cache_size=32000000
+
+# Per thread or per operation settings
+thread_stack=131072
+sort_buffer_size=32K
+read_buffer_size=8200
+read_rnd_buffer_size=8200
+max_heap_table_size=16K
+tmp_table_size=1K
+bulk_insert_buffer_size=0
+join_buffer_size=128
+net_buffer_length=1K
+innodb_sort_buffer_size=64K
+
+# Settings that relate to the binary log (if enabled)
+binlog_cache_size=4K
+binlog_stmt_cache_size=4K
+
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+# Recommended in standard MySQL setup
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid


### PR DESCRIPTION
mysql was running up 25% of memory under docker this change reduces it to more like 14%.