### PR TITLE
Remove Frontend containers (WiP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ fig.yml
 # Ignore vagrant files from testing.
 .vagrant
 Vagrantfile
+
+
+logs/*.log
+supervisord.pid

--- a/mkt/cmds.py
+++ b/mkt/cmds.py
@@ -35,7 +35,19 @@ BRANCHES = [
     'zippy',
 ]
 
-IMAGES = [
+# Local projects are run directly
+# from the tree because they only
+# build files.
+LOCAL = [
+    'fireplace',
+    'spartacus',
+]
+
+# IMAGES that need to be built.
+IMAGES = list(set(BRANCHES).difference(LOCAL))
+
+# Other images with dependency services.
+DEP_IMAGES = [
     'elasticsearch',
     'memcached',
     'mysql-data',
@@ -302,7 +314,7 @@ def check(args, parser):
             print 'Update fig, version 1.0 or higher recommended.'
 
     if args.requirements:
-        for branch in BRANCHES:
+        for branch in IMAGES:
             files = REQUIREMENTS.get(branch)
             if not files:
                 continue
@@ -411,7 +423,7 @@ def get_container_requirements(branch, files):
     project = get_project(branch)
     files_str = ' '.join([f.container for f in files])
     cmd = ('docker exec -t -i {0} /bin/bash -c "cat {1} | sha1sum"'
-            .format(get_fig_container(project).id, files_str))
+           .format(get_fig_container(project).id, files_str))
     try:
         container = subprocess.check_output(cmd, shell=True)
     except subprocess.CalledProcessError:
@@ -444,8 +456,8 @@ def get_project(project):
         return walk(new)
 
     project = project or walk(cur)
-    if project not in BRANCHES and project not in IMAGES:
-        raise ValueError('Project {0} not in BRANCHES or IMAGES'
+    if project not in IMAGES and project not in DEP_IMAGES:
+        raise ValueError('Project {0} not in IMAGES or DEP_IMAGES'
                          .format(project))
 
     return project

--- a/mkt/data/fig.yml.dist
+++ b/mkt/data/fig.yml.dist
@@ -11,17 +11,6 @@ elasticsearch:
     - "9200:9200"
     - "9300:9300"
 
-fireplace:
-  build: {tree}/fireplace
-  command: /bin/bash /srv/fireplace/src/bin/docker_run.sh
-  environment:
-    - TERM=xterm-256color
-    - BOWER_PATH=/srv/fireplace/bower_components/
-    - GULP_CONFIG_PATH=/srv/fireplace/src/config
-  volumes:
-    - {tree}/fireplace/:/srv/fireplace/src
-  working_dir: /srv/fireplace/src
-
 nginx:
   build: {image}/nginx
   command: nginx -c /etc/nginx/nginx.conf -g "daemon off;"
@@ -29,7 +18,6 @@ nginx:
     - TERM=xterm-256color
   links:
     - webpay:webpay
-    - spartacus:spartacus
     - solitude:solitude
     - zamboni:zamboni
     - zippy:zippy
@@ -76,15 +64,6 @@ solitude:
   volumes:
     - {tree}/solitude/:/srv/solitude
   working_dir: /srv/solitude
-
-spartacus:
-  build: {tree}/spartacus
-  command: "grunt docker"
-  environment:
-    - TERM=xterm-256color
-  volumes:
-    - {tree}/spartacus/:/srv/spartacus/src
-  working_dir: /srv/spartacus/src
 
 webpay:
   build: {tree}/webpay

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.2.1
 six==1.7.3
 texttable==0.8.1
 websocket-client==0.11.0
+supervisord==3.1.3

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+logfile=logs/supervisord.log
+
+[program:fireplace]
+command=make serve
+directory=%(ENV_MKT_ROOT)s/fireplace/
+autostart=true
+stopasgroup=true
+redirect_stderr=true
+stdout_logfile=./logs/fireplace.log
+stdout_logfile_maxbytes=1MB
+
+[program:spartacus]
+command=grunt start
+directory=%(ENV_MKT_ROOT)s/spartacus/
+autostart=true
+stopasgroup=true
+redirect_stderr=true
+stdout_logfile=./logs/spartacus.log
+stdout_logfile_maxbytes=1MB


### PR DESCRIPTION
 * [x] Remove frontend containers from yml
 * [x] Add supervisord conf to start fireplace and spartacus
 * [ ] Add mkt stop command to stop supervisord
 * [ ] Add docker-watch gulp command on fireplace so it builds the roll-up on changes.
 * [ ] Check similar with Spartacus.

This will mean we drop 2 containers because the front-end projects are really wasted inside docker as all they do is build static files.

Fireplace and spartacus will be run under supervisord on the host (or you could run them manually)

This will improve the front-end story for the docker dev-env quite a bit.

## To try it

```shell
mkt root $(mkt root)
fig build nginx
fig up -d # not mkt up
# Start supervisord
MKT_ROOT=$(mkt root) supervisord
```

To stop supervisord run:

`kill $(cat supervisord.pid)`


