### PR TITLE
add in locale

### DIFF
--- a/mkt/data/base-images/python27/Dockerfile
+++ b/mkt/data/base-images/python27/Dockerfile
@@ -12,8 +12,9 @@ RUN yum install -y \
     python27-python-lxml
 RUN yum install -y libxslt
 
-env PATH /opt/rh/python27/root/usr/bin:$PATH
-env LD_LIBRARY_PATH /opt/rh/python27/root/usr/lib64
+ENV PATH /opt/rh/python27/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/rh/python27/root/usr/lib64
+ENV LANG=en_US.UTF-8
 
 RUN easy_install pip
 RUN pip install ipython ipdb


### PR DESCRIPTION
Python tests fail because:

```
bash-4.1# python
Python 2.7.5 (default, Sep 12 2013, 19:47:54) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import locale
>>> locale.getdefaultlocale()
(None, None)
>>> 
```

Should be:

```
bash-4.1# export LANG=en-US.UTF-8
bash-4.1# python
Python 2.7.5 (default, Sep 12 2013, 19:47:54) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-3)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import locale
>>> locale.getdefaultlocale()
('en_US', 'UTF-8')
>>> 
```