### PR TITLE
allow switching between hub and local (bug 1116877-two)

### DIFF
--- a/mkt/data/fig.yml.dist
+++ b/mkt/data/fig.yml.dist
@@ -4,7 +4,7 @@
 #
 # You should alter the file mkt-data/fig.yml.dist.
 elasticsearch:
-  build: {image}/elasticsearch
+  {build-elasticsearch}
   environment:
     - TERM=xterm-256color
   ports:
@@ -12,7 +12,7 @@ elasticsearch:
     - "9300:9300"
 
 fireplace:
-  build: {tree}/fireplace
+  {build-fireplace}
   command: /bin/bash /srv/fireplace/src/bin/docker_run.sh
   environment:
     - TERM=xterm-256color
@@ -23,7 +23,7 @@ fireplace:
   working_dir: /srv/fireplace/src
 
 nginx:
-  build: {image}/nginx
+  {build-nginx}
   command: nginx -c /etc/nginx/nginx.conf -g "daemon off;"
   environment:
     - TERM=xterm-256color
@@ -41,7 +41,7 @@ nginx:
     - {tree}/zamboni/:/srv/zamboni
 
 memcached:
-  build: {image}/memcached
+  {build-nginx}
   command: memcached -u nobody
   environment:
     - TERM=xterm-256color
@@ -50,19 +50,19 @@ mysqldata:
   build: {image}/mysql-data
 
 mysql:
-  build: {image}/mysql-service
+  {build-mysql-service}
   environment:
     - TERM=xterm-256color
   volumes_from:
     - mysqldata
 
 redis:
-  build: {image}/redis
+  {build-redis}
   environment:
     - TERM=xterm-256color
 
 solitude:
-  build: {tree}/solitude
+  {build-solitude}
   command: supervisord -n -c /srv/solitude/bin/docker/supervisor.conf
   environment:
     - PYTHONUNBUFFERED=1
@@ -78,7 +78,7 @@ solitude:
   working_dir: /srv/solitude
 
 spartacus:
-  build: {tree}/spartacus
+  {build-spartacus}
   command: "grunt docker"
   environment:
     - TERM=xterm-256color
@@ -87,7 +87,7 @@ spartacus:
   working_dir: /srv/spartacus/src
 
 webpay:
-  build: {tree}/webpay
+  {build-webpay}
   command: supervisord -n -c /srv/webpay/bin/docker/supervisor.conf
   environment:
     - MKT_HOSTNAME=mp.dev
@@ -103,7 +103,7 @@ webpay:
   working_dir: /srv/webpay
 
 zamboni:
-  build: {tree}/zamboni
+  {build-zamboni}
   command: supervisord -n -c /srv/zamboni/scripts/docker/supervisor.conf
   environment:
     - FXA_CLIENT_ID=7943afb7b9f54089
@@ -121,7 +121,7 @@ zamboni:
   working_dir: /srv/zamboni
 
 zippy:
-  build: {tree}/zippy
+  {build-zippy}
   command: "grunt start --port 2605 --noauth"
   environment:
     - TERM=xterm-256color


### PR DESCRIPTION
```
[1116877-two] marketplace-env $ mkt root
/Users/andy/sandboxes
[1116877-two] marketplace-env $ mkt root ~/sandboxes/
Saving root to /Users/andy/.wharfie
[1116877-two] marketplace-env $ mkt root ~/sandboxes/ --use-hub
Saving root to /Users/andy/.wharfie
Saving build to /Users/andy/.wharfie
[1116877-two] marketplace-env $ grep "^elasticsearch:" ~/.mkt.fig.yml -A 1
elasticsearch:
  image: mozillamarketplace/elasticsearch
[1116877-two] marketplace-env $ mkt root ~/sandboxes/ --build-locally
Saving root to /Users/andy/.wharfie
Saving build to /Users/andy/.wharfie
Written fig file to /Users/andy/.mkt.fig.yml
[1116877-two] marketplace-env $ grep "^elasticsearch:" ~/.mkt.fig.yml -A 1
elasticsearch:
  build: /Users/andy/sandboxes/marketplace-env/mkt/data/images/elasticsearch
```