### PR TITLE
Allow mkt bash [project] to match docs (fixes #69)

### DIFF
--- a/mkt/cmds.py
+++ b/mkt/cmds.py
@@ -622,9 +622,9 @@ def create_parser():
         'bash', help='Run a bash shell on a running container.'
     )
     parser_bash.add_argument(
-        '--project',
+        'project',
         help='Project name, if not given will be calculated.',
-        action='store')
+        default=None, nargs='?')
     parser_bash.set_defaults(func=bash)
 
     parser_update = subparsers.add_parser(


### PR DESCRIPTION
e.g. this now requires `mkt bash zamboni` rather than `mkt bash --project zamboni` which is what the docs already say it does.