### PR TITLE
Configure ES for lower memory usage

### DIFF
--- a/mkt/data/fig.yml.dist
+++ b/mkt/data/fig.yml.dist
@@ -7,6 +7,8 @@ elasticsearch:
   {build-elasticsearch}
   environment:
     - TERM=xterm-256color
+    - ES_MIN_MEM=128m
+    - ES_MAX_MEM=512m
   ports:
     - "9200:9200"
     - "9300:9300"


### PR DESCRIPTION
The defaults here are 256m min and 1g max this lowers that to something a little better for local dev puposes.

I've  been running this for a few days and haven't yet seen any issues yet.