### PR TITLE
do some yum cleaning

### DIFF
--- a/mkt/data/base-images/mysql/Dockerfile
+++ b/mkt/data/base-images/mysql/Dockerfile
@@ -1,4 +1,4 @@
 FROM mozillamarketplace/centos-python27-mkt:0.6
 
 ADD yum/mysql.repo /etc/yum.repos.d/mysql.repo
-RUN yum install -y mysql-community-server mysql-community-devel
+RUN yum install -y mysql-community-server mysql-community-devel && yum clean all

--- a/mkt/data/base-images/python27/Dockerfile
+++ b/mkt/data/base-images/python27/Dockerfile
@@ -1,16 +1,9 @@
 FROM centos:centos6
 
-ADD yum/mkt.repo  /etc/yum.repos.d/mkt.repo
+ADD yum/mkt.repo /etc/yum.repos.d/mkt.repo
 
-RUN yum install -y python27
-
-RUN yum install -y git
-RUN yum install -y gcc
-
-RUN yum install -y \
-    python27-m2crypto \
-    python27-python-lxml
-RUN yum install -y libxslt
+RUN yum install -y python27 git gcc && yum clean all
+RUN yum install -y python27-m2crypto python27-python-lxml libxslt && yum clean all
 
 ENV PATH /opt/rh/python27/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/rh/python27/root/usr/lib64


### PR DESCRIPTION
```
 slimmer python27 $ docker history marketplace/python27:slimmer
IMAGE               CREATED             CREATED BY                                      SIZE
f12a163c8d1c        11 seconds ago      /bin/sh -c pip install ipython ipdb             18.65 MB
5f07e7178d3f        16 seconds ago      /bin/sh -c easy_install pip                     6.181 MB
e5f43c5aa011        19 seconds ago      /bin/sh -c #(nop) ENV LANG=en_US.UTF-8          0 B
44b49d7609c4        19 seconds ago      /bin/sh -c #(nop) ENV LD_LIBRARY_PATH=/opt/rh   0 B
39bfe23f7165        20 seconds ago      /bin/sh -c #(nop) ENV PATH=/opt/rh/python27/r   0 B
86a48c01ecda        20 seconds ago      /bin/sh -c yum install -y     python27-m2cryp   25.4 MB
c6b4e14b1890        37 seconds ago      /bin/sh -c yum install -y python27 git gcc &&   280.4 MB
dcddf0451a27        6 minutes ago       /bin/sh -c #(nop) ADD file:813e789ea49480c7cc   123 B
b9aeeaeb5e17        4 weeks ago         /bin/sh -c #(nop) ADD file:2b2b26209d285cd1a9   202.6 MB
f1b10cd84249        4 weeks ago         /bin/sh -c #(nop) MAINTAINER The CentOS Proje   0 B
```