### PR TITLE
fix mysql and limit pip version

### DIFF
--- a/docker/base-images/mysql/Dockerfile
+++ b/docker/base-images/mysql/Dockerfile
@@ -1,4 +1,11 @@
 FROM mozillamarketplace/centos-python27-mkt:latest
 
 ADD yum/mysql.repo /etc/yum.repos.d/mysql.repo
-RUN yum install -y mysql-community-server mysql-community-devel && yum clean all
+RUN yum install -y \
+    mysql-community-server \
+    mysql-community-devel \
+    # The MySQL Python wheel used on production is compiled with
+    # libmysqlclient_r.so.16, so we need to install this to get
+    # that wheel to work.
+    mysql-community-libs-compat-5.6.14-3.el6.x86_64 \
+    && yum clean all

--- a/docker/base-images/python27/Dockerfile
+++ b/docker/base-images/python27/Dockerfile
@@ -9,5 +9,6 @@ ENV PATH /opt/rh/python27/root/usr/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/rh/python27/root/usr/lib64
 ENV LANG en_US.UTF-8
 
-RUN easy_install pip
+# Peep won't work with pip 7 yet.
+RUN easy_install pip<7
 RUN pip install ipython ipdb


### PR DESCRIPTION
There is a wheel of MySQLPython on pyrepo that uses libmysqlclient 16. That's probably closer to what production uses. This installs that lib so that it works.

Also limit pip to below version 7 so we can use peep.